### PR TITLE
Corregir las cuatro alertas CodeQL de path injection

### DIFF
--- a/src-api/src/main/java/com/taemoi/project/services/impl/DocumentoServiceImpl.java
+++ b/src-api/src/main/java/com/taemoi/project/services/impl/DocumentoServiceImpl.java
@@ -61,7 +61,8 @@ public class DocumentoServiceImpl implements DocumentoService {
 			throw new IllegalStateException("Sistema operativo no soportado: " + os);
 		}
 
-		Path rutaBaseDocumentos = Path.of(directorioDocumentos, "Documentos_Alumnos_Moiskimdo");
+		Path rutaBaseDocumentos = Path.of(directorioDocumentos, "Documentos_Alumnos_Moiskimdo")
+				.toAbsolutePath().normalize();
 		if (!Files.exists(rutaBaseDocumentos)) {
 			Files.createDirectories(rutaBaseDocumentos);
 		}
@@ -79,7 +80,10 @@ public class DocumentoServiceImpl implements DocumentoService {
 			String nombreLimpio = FileUtils.limpiarNombreArchivo(alumno.getNombre());
 			String apellidosLimpio = FileUtils.limpiarNombreArchivo(alumno.getApellidos());
 			String carpetaAlumno = alumno.getNumeroExpediente() + "_" + nombreLimpio + "_" + apellidosLimpio;
-			rutaCarpetaAlumno = rutaBaseDocumentos.resolve(carpetaAlumno);
+			rutaCarpetaAlumno = rutaBaseDocumentos.resolve(carpetaAlumno).normalize();
+			if (!rutaCarpetaAlumno.startsWith(rutaBaseDocumentos)) {
+				throw new IllegalArgumentException("Ruta de alumno fuera del directorio permitido.");
+			}
 			logger.info("*** New folder path: {}", rutaCarpetaAlumno);
 
 			if (!Files.exists(rutaCarpetaAlumno)) {
@@ -94,7 +98,14 @@ public class DocumentoServiceImpl implements DocumentoService {
 		String mimeTypeSeguro = DocumentoSecurityUtils.detectarMimePermitido(nombreOriginalLimpio, archivo.getContentType());
 		String nombreArchivoFinal = nombreOriginalLimpio;
 
-		Path rutaArchivoFinal = rutaCarpetaAlumno.resolve(nombreArchivoFinal);
+		Path rutaCarpetaAlumnoSegura = rutaCarpetaAlumno.toAbsolutePath().normalize();
+		Path rutaArchivoFinal = rutaCarpetaAlumnoSegura.resolve(nombreArchivoFinal).normalize().toAbsolutePath();
+		if (!rutaCarpetaAlumnoSegura.startsWith(rutaBaseDocumentos)
+				|| !rutaArchivoFinal.startsWith(rutaCarpetaAlumnoSegura)
+				|| !rutaCarpetaAlumnoSegura.equals(rutaArchivoFinal.getParent())
+				|| !rutaArchivoFinal.startsWith(rutaBaseDocumentos)) {
+			throw new IllegalArgumentException("Ruta de documento fuera del directorio permitido.");
+		}
 		Files.copy(archivo.getInputStream(), rutaArchivoFinal, StandardCopyOption.REPLACE_EXISTING);
 
 		// Use the actual folder name (not the generated one) for the URL
@@ -136,14 +147,18 @@ public class DocumentoServiceImpl implements DocumentoService {
 			throw new IllegalStateException("Sistema operativo no soportado: " + os);
 		}
 
-		Path rutaBaseDocumentos = Path.of(directorioDocumentos, "Documentos_Eventos");
+		Path rutaBaseDocumentos = Path.of(directorioDocumentos, "Documentos_Eventos")
+				.toAbsolutePath().normalize();
 		if (!Files.exists(rutaBaseDocumentos)) {
 			Files.createDirectories(rutaBaseDocumentos);
 		}
 
 		String tituloLimpio = FileUtils.limpiarNombreArchivo(evento.getTitulo());
 		String carpetaEvento = evento.getId() + "_" + tituloLimpio;
-		Path rutaCarpetaEvento = rutaBaseDocumentos.resolve(carpetaEvento);
+		Path rutaCarpetaEvento = rutaBaseDocumentos.resolve(carpetaEvento).normalize();
+		if (!rutaCarpetaEvento.startsWith(rutaBaseDocumentos)) {
+			throw new IllegalArgumentException("Ruta de evento fuera del directorio permitido.");
+		}
 
 		if (!Files.exists(rutaCarpetaEvento)) {
 			Files.createDirectories(rutaCarpetaEvento);
@@ -153,7 +168,13 @@ public class DocumentoServiceImpl implements DocumentoService {
 		String nombreOriginalLimpio = FileUtils.limpiarNombreArchivo(nombreOriginalArchivo);
 		String mimeTypeSeguro = DocumentoSecurityUtils.detectarMimePermitido(nombreOriginalLimpio, archivo.getContentType());
 
-		Path rutaArchivoFinal = rutaCarpetaEvento.resolve(nombreOriginalLimpio);
+		Path rutaCarpetaEventoSegura = rutaCarpetaEvento.toAbsolutePath().normalize();
+		Path rutaArchivoFinal = rutaCarpetaEventoSegura.resolve(nombreOriginalLimpio).normalize().toAbsolutePath();
+		if (!rutaArchivoFinal.startsWith(rutaCarpetaEventoSegura)
+				|| !rutaCarpetaEventoSegura.equals(rutaArchivoFinal.getParent())
+				|| !rutaArchivoFinal.startsWith(rutaBaseDocumentos)) {
+			throw new IllegalArgumentException("Ruta de documento fuera del directorio permitido.");
+		}
 		Files.copy(archivo.getInputStream(), rutaArchivoFinal, StandardCopyOption.REPLACE_EXISTING);
 
 		String urlAcceso = "%s/documentos/Documentos_Eventos/%s/%s".formatted(baseUrl, carpetaEvento, nombreOriginalLimpio);

--- a/src-api/src/main/java/com/taemoi/project/services/impl/ImagenServiceImpl.java
+++ b/src-api/src/main/java/com/taemoi/project/services/impl/ImagenServiceImpl.java
@@ -116,7 +116,7 @@ public class ImagenServiceImpl implements ImagenService {
 			throw new IllegalStateException("Sistema operativo no soportado: " + os);
 		}
 
-		return Path.of(directorioImagenes);
+		return Path.of(directorioImagenes).toAbsolutePath().normalize();
 	}
 
 	private BufferedImage redimensionarParaEvento(BufferedImage original) {
@@ -145,7 +145,14 @@ public class ImagenServiceImpl implements ImagenService {
 		return salida;
 	}
 
-	private void guardarComoWebp(BufferedImage imagen, Path rutaArchivo, float quality) throws IOException {
+	private Path guardarComoWebp(BufferedImage imagen, Path directorioDestino, String nombreArchivo, float quality)
+			throws IOException {
+		Path directorioSeguro = directorioDestino.toAbsolutePath().normalize();
+		Path rutaArchivo = directorioSeguro.resolve(nombreArchivo).normalize().toAbsolutePath();
+		if (!rutaArchivo.startsWith(directorioSeguro) || !directorioSeguro.equals(rutaArchivo.getParent())) {
+			throw new IllegalArgumentException("Ruta de imagen fuera del directorio permitido.");
+		}
+
 		Iterator<ImageWriter> writers = ImageIO.getImageWritersByMIMEType("image/webp");
 		if (!writers.hasNext()) {
 			writers = ImageIO.getImageWritersBySuffix("webp");
@@ -166,9 +173,17 @@ public class ImagenServiceImpl implements ImagenService {
 		} finally {
 			writer.dispose();
 		}
+		return rutaArchivo;
 	}
 
-	private void guardarComoJpeg(BufferedImage imagen, Path rutaArchivo, float quality) throws IOException {
+	private Path guardarComoJpeg(BufferedImage imagen, Path directorioDestino, String nombreArchivo, float quality)
+			throws IOException {
+		Path directorioSeguro = directorioDestino.toAbsolutePath().normalize();
+		Path rutaArchivo = directorioSeguro.resolve(nombreArchivo).normalize().toAbsolutePath();
+		if (!rutaArchivo.startsWith(directorioSeguro) || !directorioSeguro.equals(rutaArchivo.getParent())) {
+			throw new IllegalArgumentException("Ruta de imagen fuera del directorio permitido.");
+		}
+
 		Iterator<ImageWriter> writers = ImageIO.getImageWritersByFormatName("jpeg");
 		if (!writers.hasNext()) {
 			writers = ImageIO.getImageWritersByMIMEType("image/jpeg");
@@ -191,23 +206,22 @@ public class ImagenServiceImpl implements ImagenService {
 		} finally {
 			writer.dispose();
 		}
+		return rutaArchivo;
 	}
 
 	private Imagen guardarImagenProcesadaConFallback(BufferedImage imagen, Path directorioDestino, String nombreBase,
 			String carpetaPublica, float webpQuality) throws IOException {
 		String nombreBaseArchivo = UUID.randomUUID() + "_" + nombreBase;
 		String nombreWebp = nombreBaseArchivo + ".webp";
-		Path rutaWebp = directorioDestino.resolve(nombreWebp);
 		try {
-			guardarComoWebp(imagen, rutaWebp, webpQuality);
+			Path rutaWebp = guardarComoWebp(imagen, directorioDestino, nombreWebp, webpQuality);
 			String urlAcceso = baseUrl + "/imagenes/" + carpetaPublica + "/" + nombreWebp;
 			return new Imagen(nombreWebp, "image/webp", urlAcceso, rutaWebp.toString());
 		} catch (Exception e) {
 			logger.warn("Fallo al guardar imagen en WebP, se usara fallback JPEG. Carpeta: {}, nombreBase: {}. Causa: {}",
 					carpetaPublica, nombreBase, e.getMessage());
 			String nombreJpeg = nombreBaseArchivo + ".jpg";
-			Path rutaJpeg = directorioDestino.resolve(nombreJpeg);
-			guardarComoJpeg(imagen, rutaJpeg, JPEG_FALLBACK_QUALITY);
+			Path rutaJpeg = guardarComoJpeg(imagen, directorioDestino, nombreJpeg, JPEG_FALLBACK_QUALITY);
 			String urlAcceso = baseUrl + "/imagenes/" + carpetaPublica + "/" + nombreJpeg;
 			return new Imagen(nombreJpeg, "image/jpeg", urlAcceso, rutaJpeg.toString());
 		}

--- a/src-api/src/test/java/com/taemoi/project/servicios/DocumentoServiceImplTest.java
+++ b/src-api/src/test/java/com/taemoi/project/servicios/DocumentoServiceImplTest.java
@@ -21,6 +21,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.mock.web.MockMultipartFile;
 
+import com.taemoi.project.entities.Alumno;
 import com.taemoi.project.entities.Evento;
 import com.taemoi.project.entities.Documento;
 import com.taemoi.project.repositories.DocumentoRepository;
@@ -237,6 +238,32 @@ class DocumentoServiceImplTest {
 
 		assertEquals("application/vnd.openxmlformats-officedocument.wordprocessingml.document", documento.getTipo());
 		assertTrue(documento.getNombre().endsWith(".docx"));
+	}
+
+	@Test
+	void guardarDocumento_debeMantenerLaEscrituraDentroDelDirectorioPermitido() throws Exception {
+		ReflectionTestUtils.setField(documentoService, "directorioDocumentosLinux", tempDir.toString());
+		ReflectionTestUtils.setField(documentoService, "directorioDocumentosWindows", tempDir.toString());
+		ReflectionTestUtils.setField(documentoService, "baseUrl", "http://localhost:8080");
+		when(documentoRepository.save(org.mockito.ArgumentMatchers.any(Documento.class)))
+				.thenAnswer(invocation -> invocation.getArgument(0));
+
+		Alumno alumno = new Alumno();
+		alumno.setNumeroExpediente(27);
+		alumno.setNombre("../../Ana");
+		alumno.setApellidos("../Prueba");
+		MultipartFile archivo = new MockMultipartFile(
+				"archivo",
+				"../../documento.pdf",
+				"application/pdf",
+				"contenido-pdf".getBytes());
+
+		Documento documento = documentoService.guardarDocumento(alumno, archivo);
+
+		Path basePermitida = tempDir.resolve("Documentos_Alumnos_Moiskimdo").toAbsolutePath().normalize();
+		Path rutaGuardada = tempDir.resolve(documento.getRuta()).toAbsolutePath().normalize();
+		assertTrue(rutaGuardada.startsWith(basePermitida));
+		assertTrue(Files.exists(rutaGuardada));
 	}
 
 	private Documento crearDocumento(String ruta, String nombre) {

--- a/src-api/src/test/java/com/taemoi/project/servicios/ImagenServiceImplTest.java
+++ b/src-api/src/test/java/com/taemoi/project/servicios/ImagenServiceImplTest.java
@@ -1,0 +1,57 @@
+package com.taemoi.project.servicios;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import javax.imageio.ImageIO;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.taemoi.project.entities.Imagen;
+import com.taemoi.project.services.impl.ImagenServiceImpl;
+
+class ImagenServiceImplTest {
+
+	@TempDir
+	Path tempDir;
+
+	@Test
+	void guardarImagenes_debeMantenerLasEscriturasDentroDeLosDirectoriosPermitidos() throws Exception {
+		ImagenServiceImpl imagenService = new ImagenServiceImpl();
+		ReflectionTestUtils.setField(imagenService, "directorioImagenesLinux", tempDir.toString());
+		ReflectionTestUtils.setField(imagenService, "directorioImagenesWindows", tempDir.toString());
+		ReflectionTestUtils.setField(imagenService, "baseUrl", "http://localhost:8080");
+
+		byte[] contenidoImagen = crearPng();
+		Imagen imagenAlumno = imagenService.guardarImagen(new MockMultipartFile(
+				"archivo", "../../foto.png", "image/png", contenidoImagen));
+		Imagen imagenEvento = imagenService.guardarImagenEvento(new MockMultipartFile(
+				"archivo", "..\\..\\cartel.png", "image/png", contenidoImagen));
+
+		assertRutaDentroDelDirectorio(imagenAlumno, tempDir.resolve("alumnos"));
+		assertRutaDentroDelDirectorio(imagenEvento, tempDir.resolve("eventos"));
+	}
+
+	private byte[] crearPng() throws Exception {
+		BufferedImage imagen = new BufferedImage(8, 8, BufferedImage.TYPE_INT_RGB);
+		ByteArrayOutputStream output = new ByteArrayOutputStream();
+		ImageIO.write(imagen, "png", output);
+		return output.toByteArray();
+	}
+
+	private void assertRutaDentroDelDirectorio(Imagen imagen, Path directorioPermitido) {
+		Path directorioSeguro = directorioPermitido.toAbsolutePath().normalize();
+		Path rutaGuardada = Path.of(imagen.getRuta()).toAbsolutePath().normalize();
+		assertTrue(rutaGuardada.startsWith(directorioSeguro));
+		assertEquals(directorioSeguro, rutaGuardada.getParent());
+		assertTrue(Files.exists(rutaGuardada));
+	}
+}


### PR DESCRIPTION
  ## Resumen

  Corrige las cuatro alertas de severidad alta detectadas por CodeQL
  relacionadas con la construcción de rutas para documentos e imágenes.

  ## Cambios

  - Normaliza las rutas base y de destino antes de escribir archivos.
  - Comprueba que cada archivo permanece dentro del directorio permitido.
  - Impide que los nombres manipulados creen rutas o subdirectorios
    inesperados.
  - Protege la subida de documentos de alumnos y eventos.
    recorrido de directorios.

  ## Alertas corregidas

  - CodeQL #6: escritura de imágenes JPEG.

  ## Validación

  - Pruebas específicas de documentos e imágenes superadas.
  - Suite completa del backend superada.
  - Compilación del backend completada correctamente.

  CodeQL volverá a analizar los cambios y cerrará las alertas correspondientes
  cuando la corrección llegue a `main`.